### PR TITLE
Fix paused audio class removal

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -34,14 +34,14 @@ let audioPlayer = {
 		// set state
 		this.playing = true;
 	},
-	pause: function (name) {
-		if (this.playing){
-			// stop audio
-			$('.board-button.active').removeClass('.active');
-			this.currentlyPlaying.trigger('pause')
-			this.playing = false;
-		}
-	}
+        pause: function (name) {
+                if (this.playing){
+                        // stop audio
+                        $('.cell.active').removeClass('active');
+                        this.currentlyPlaying.trigger('pause');
+                        this.playing = false;
+                }
+        }
 }
 
 // button handler


### PR DESCRIPTION
## Summary
- fix the selector used to clear active audio cells

## Testing
- `node --check scripts/scripts.js`

------
https://chatgpt.com/codex/tasks/task_e_688809689dc88321b46e2c58d03f4470