### PR TITLE
Add asset validation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,11 @@
 Second version of the In Transit project, optimized for smaller screens and deployed
 
 -- Adam Levy and Alex Brook Lynn
+
+## Running tests
+
+Run the unit tests with:
+
+```bash
+python -m unittest
+```

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,0 +1,29 @@
+import unittest
+from pathlib import Path
+from html.parser import HTMLParser
+
+class SrcCollector(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.sources = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag in {"img", "audio"}:
+            attrs_dict = dict(attrs)
+            src = attrs_dict.get("src")
+            if src:
+                self.sources.append(src)
+
+class TestAssetsExist(unittest.TestCase):
+    def test_assets_referenced_in_index_exist(self):
+        project_root = Path(__file__).resolve().parents[1]
+        index_path = project_root / "index.html"
+        html = index_path.read_text(encoding="utf-8")
+        parser = SrcCollector()
+        parser.feed(html)
+        missing = [src for src in parser.sources if not (project_root / src).exists()]
+        self.assertEqual(missing, [], f"Missing asset files: {missing}")
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add unit test ensuring assets referenced from index.html exist
- document how to run the tests

## Testing
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_68880b5d5b6883219a7c4388c833c4dd