### PR TITLE
Add pulsing paused state to audio progress bars

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -8,35 +8,52 @@ class AudioPlayer {
     }
 
     play(element) {
-        const name = element.id;
-        this.pause();
+        const audio = element.querySelector('audio');
+        const progress = element.querySelector('.progress');
 
-        if (this.currentlyPlaying && this.currentlyPlaying.id === `${name}-audio`) {
-            element.classList.remove('active');
-            this.playing = false;
-            this.currentlyPlaying = null;
+        // Toggle pause/play if clicking the same element
+        if (this.currentlyPlaying === audio) {
+            if (this.playing) {
+                this.pause(true);
+            } else {
+                this.currentlyPlaying.play();
+                this.playing = true;
+                this.progressIndicator.classList.remove('paused');
+            }
             return;
         }
 
-        this.currentlyPlaying = element.querySelector('audio');
-        this.currentlyPlaying.play();
+        // New element clicked, reset all progress bars and stop current audio
+        this.pause();
+        document.querySelectorAll('.progress').forEach(p => {
+            p.classList.remove('paused');
+            p.style.width = '0%';
+        });
 
-        const progress = element.querySelector('.progress');
-        progress.style.display = 'block';
+        this.currentlyPlaying = audio;
+        this.progressIndicator = progress;
+        this.currentlyPlaying.currentTime = 0;
+        this.currentlyPlaying.play();
+        this.playing = true;
 
         this.currentlyPlaying.addEventListener('timeupdate', () => {
             const percent = (this.currentlyPlaying.currentTime / this.currentlyPlaying.duration) * 100;
-            progress.style.width = `${percent}%`;
+            this.progressIndicator.style.width = `${percent}%`;
         });
-        this.progressIndicator = progress;
-        this.playing = true;
     }
 
-    pause() {
-        if (this.playing && this.currentlyPlaying) {
-            document.querySelectorAll('.cell.active').forEach(el => el.classList.remove('active'));
+    pause(showPaused = false) {
+        if (this.currentlyPlaying) {
             this.currentlyPlaying.pause();
             this.playing = false;
+            if (showPaused) {
+                this.progressIndicator.classList.add('paused');
+            } else {
+                this.progressIndicator && this.progressIndicator.classList.remove('paused');
+                this.progressIndicator && (this.progressIndicator.style.width = '0%');
+                this.currentlyPlaying = null;
+                this.progressIndicator = null;
+            }
         }
     }
 }
@@ -45,7 +62,6 @@ const audioPlayer = new AudioPlayer();
 
 document.querySelectorAll('.cell').forEach(cell => {
     cell.addEventListener('click', () => {
-        document.querySelectorAll('.progress').forEach(p => p.style.display = 'none');
         audioPlayer.play(cell);
     });
 });

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -33,6 +33,17 @@ body {
     opacity: 0.7;
     transition: all 0.1s ease-in;
 }
+
+.cell .progress.paused {
+    opacity: 0.4;
+    animation: pausedPulse 1s infinite;
+}
+
+@keyframes pausedPulse {
+    0% { opacity: 0.4; }
+    50% { opacity: 0.2; }
+    100% { opacity: 0.4; }
+}
 @media screen and (min-width: 640px) {
   .cell {
 	  width: 50%;


### PR DESCRIPTION
## Summary
- Keep progress bar visible when playback is paused
- Pulse progress bar with lower opacity to indicate paused status
- Reset playhead on all other cells when switching playback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b93037ee483218a4f15f1e50e16d6