### PR TITLE
Generate city cells from YAML

### DIFF
--- a/assets/cities.yaml
+++ b/assets/cities.yaml
@@ -1,0 +1,35 @@
+- id: nyc
+  titleImg: assets/titles/new-york.svg
+  alt: "New York City"
+  audio: assets/sounds/nyc.mp3
+  bg: "#000000"
+
+- id: paris
+  titleImg: assets/titles/paris.png
+  alt: "Paris"
+  audio: assets/sounds/paris.mp3
+  bg: "#86DFE3"
+
+- id: montreal
+  titleImg: assets/titles/montreal.svg
+  alt: "Montreal"
+  audio: assets/sounds/montreal.mp3
+  bg: "#7058ee"
+
+- id: mexicocity
+  titleImg: assets/titles/mexico-city.png
+  alt: "Mexico City"
+  audio: assets/sounds/mexicocity.mp3
+  bg: "#ce0786"
+
+- id: bangkok
+  titleImg: assets/titles/bangkok.png
+  alt: "Bangkok"
+  audio: assets/sounds/bangkok.mp3
+  bg: "#C60013"
+
+- id: dc
+  titleImg: assets/titles/dc.png
+  alt: "Washington, DC"
+  audio: assets/sounds/dc.m4a
+  bg: "#000000"

--- a/index.html
+++ b/index.html
@@ -1,54 +1,18 @@
 <head>
-	<meta charset="utf-8">
-	<meta http-equiv="x-ua-compatible" content="ie=edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<title>In Transit</title>
-	<link rel="stylesheet" href="styles/styles.css" type="text/css" media="screen" />
-	
+        <meta charset="utf-8">
+        <meta http-equiv="x-ua-compatible" content="ie=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <title>In Transit</title>
+        <link rel="stylesheet" href="styles/styles.css" type="text/css" media="screen" />
+
 </head>
 <body id="main">
-	<div id="container">
-		<div class="cell" id="intro">
-			<img src="assets/titles/intro.png" alt="intro" style="background-color: white;"/>
-			<audio preload="auto" src="assets/sounds/intro.mp3" id="intro-audio"></audio>
-			<div class="progress"></div>
-		</div>
-		<!-- New York -->
-		<div class="cell" id="nyc" style="background-color: black;">
-			<img src="assets/titles/new-york.svg" alt="New York City" />
-			<audio preload="auto" src="assets/sounds/nyc.mp3" id="nyc-audio"></audio>
-			<div class="progress"></div>
-		</div>
-		<!-- Paris -->
-		<div class="cell" id="paris" style="background-color: #86DFE3;">
-			<img src="assets/titles/paris.png" alt="Paris" />
-			<audio preload="auto" src="assets/sounds/paris.mp3" id="paris-audio"></audio>
-			<div class="progress"></div>
-		</div>
-		<!-- Montreal -->
-		<div class="cell" id="montreal" style="background-color:#7058ee;">
-			<img src="assets/titles/montreal.svg" alt="Montreal" />
-			<audio preload="auto" src="assets/sounds/montreal.mp3" id="montreal-audio"></audio>
-			<div class="progress"></div>
-		</div>
-		<!-- Mexico City -->
-		<div class="cell" id="mexicocity" style="background-color:#ce0786;">
-			<img src="assets/titles/mexico-city.png" alt="Mexico City" />
-			<audio preload="auto" src="assets/sounds/mexicocity.mp3" id="mexicocity-audio"></audio>
-			<div class="progress"></div>
-		</div>
-		<!-- Bangkok -->
-		<div class="cell" id="bangkok" style="background-color:#C60013;">
-			<img src="assets/titles/bangkok.png" alt="Bangkok" />
-			<audio preload="auto" src="assets/sounds/bangkok.mp3" id="bangkok-audio"></audio>
-			<div class="progress"></div>
-		</div>
-                 <!-- Washington, DC -->
-		<div class="cell" id="dc" style="background-color: black;">
-			<img src="assets/titles/dc.png" alt="Washington, DC" />
-			<audio preload="auto" src="assets/sounds/dc.m4a" id="dc-audio"></audio>
-			<div class="progress"></div>
-		</div>
-	</div>
+        <div id="container">
+                <div class="cell" id="intro">
+                        <img src="assets/titles/intro.png" alt="intro" style="background-color: white;"/>
+                        <audio preload="auto" src="assets/sounds/intro.mp3" id="intro-audio"></audio>
+                        <div class="progress"></div>
+                </div>
+        </div>
+        <script type="module" src="scripts/scripts.js"></script>
 </body>
-<script type="module" src="scripts/scripts.js"></script>

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1,3 +1,5 @@
+import yaml from 'https://cdn.jsdelivr.net/npm/js-yaml/+esm';
+
 // Modern JavaScript audio player without jQuery
 
 class AudioPlayer {
@@ -60,10 +62,33 @@ class AudioPlayer {
 
 const audioPlayer = new AudioPlayer();
 
-document.querySelectorAll('.cell').forEach(cell => {
-    cell.addEventListener('click', () => {
-        audioPlayer.play(cell);
-    });
-});
+async function buildCells() {
+    const text = await fetch('assets/cities.yaml').then(r => r.text());
+    const cities = yaml.load(text);
+    const container = document.querySelector('#container');
 
-window.audioPlayer = audioPlayer;
+    for (const city of cities) {
+        const cell = document.createElement('div');
+        cell.className = 'cell';
+        cell.id = city.id;
+        cell.style.backgroundColor = city.bg;
+
+        cell.innerHTML = `
+      <img src="${city.titleImg}" alt="${city.alt}">
+      <audio preload="auto" src="${city.audio}" id="${city.id}-audio"></audio>
+      <div class="progress"></div>
+    `;
+
+        container.appendChild(cell);
+    }
+}
+
+async function init() {
+    await buildCells();
+    document.querySelectorAll('.cell').forEach(cell => {
+        cell.addEventListener('click', () => audioPlayer.play(cell));
+    });
+    window.audioPlayer = audioPlayer;
+}
+
+init();

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -21,9 +21,19 @@ class TestAssetsExist(unittest.TestCase):
         html = index_path.read_text(encoding="utf-8")
         parser = SrcCollector()
         parser.feed(html)
-        missing = [src for src in parser.sources if not (project_root / src).exists()]
+        sources = list(parser.sources)
+
+        cities_yaml = project_root / "assets" / "cities.yaml"
+        if cities_yaml.exists():
+            for line in cities_yaml.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if line.startswith("titleImg:") or line.startswith("audio:"):
+                    sources.append(line.split(":", 1)[1].strip().strip("'\""))
+
+        missing = [src for src in sources if not (project_root / src).exists()]
         self.assertEqual(missing, [], f"Missing asset files: {missing}")
 
 if __name__ == "__main__":
     unittest.main()
+
 


### PR DESCRIPTION
## Summary
- Dynamically build city cells from a YAML config file
- Load js-yaml at runtime and autowire cells before audio player init
- Extend asset test to validate paths declared in cities.yaml

## Testing
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_689b9729f5c08321af436bd7155b0f43