### PR TITLE
Add service worker for offline audio playback

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -92,3 +92,10 @@ async function init() {
 }
 
 init();
+
+if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/service-worker.js');
+    });
+}
+

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,41 @@
+const CACHE_NAME = 'in-transit-cache-v1';
+const CORE_ASSETS = [
+  '/',
+  '/index.html',
+  '/scripts/scripts.js',
+  '/styles/styles.css',
+  '/assets/cities.yaml',
+  'https://cdn.jsdelivr.net/npm/js-yaml/+esm'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(CORE_ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+      )
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => {
+      if (response) {
+        return response;
+      }
+      return fetch(event.request).then(fetchResponse => {
+        const clone = fetchResponse.clone();
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, clone));
+        return fetchResponse;
+      }).catch(() => caches.match('/index.html'));
+    })
+  );
+});
+


### PR DESCRIPTION
## Summary
- add service worker to cache core assets and fetches for offline playback
- register service worker during app initialization

## Testing
- `python -m unittest`


------
https://chatgpt.com/codex/tasks/task_e_68aa1cc313e083218e8571b68a2947eb